### PR TITLE
add meta.mainProgram

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,8 @@
 		  patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/vaapitest
 		  wrapProgram $out/bin/vaapitest --set LD_LIBRARY_PATH "${pkgs.lib.makeLibraryPath runtimeLibs}"
 		'';
+
+    meta.mainProgram = "zen";
 	      };
     in
     {


### PR DESCRIPTION
Allows the browser to be run by using `nix run github:MarceColl/zen-browser-flake`.