### PR TITLE
Update to 1.0.0-a.28, fix VAAPI decoding and Pipewire

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,8 +27,11 @@
       runtimeLibs = with pkgs; [
         libGL stdenv.cc.cc fontconfig libxkbcommon zlib freetype
         gtk3 libxml2 dbus xcb-util-cursor alsa-lib pango atk cairo gdk-pixbuf glib
+	udev libva mesa libnotify cups pciutils
+	ffmpeg libglvnd
       ] ++ (with pkgs.xorg; [
-        libxcb libX11 libXcursor libXrandr libXi libXext libXcomposite libXdamage libXfixes
+        libxcb libX11 libXcursor libXrandr libXi libXext libXcomposite libXdamage
+	libXfixes libXScrnSaver
       ]);
 
       mkZen = { variant }: 

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
         libGL stdenv.cc.cc fontconfig libxkbcommon zlib freetype
         gtk3 libxml2 dbus xcb-util-cursor alsa-lib pango atk cairo gdk-pixbuf glib
 	udev libva mesa libnotify cups pciutils
-	ffmpeg libglvnd
+	ffmpeg libglvnd pipewire
       ] ++ (with pkgs.xorg; [
         libxcb libX11 libXcursor libXrandr libXi libXext libXcomposite libXdamage
 	libXfixes libXScrnSaver

--- a/flake.nix
+++ b/flake.nix
@@ -8,15 +8,15 @@
   outputs = { self, nixpkgs }:
     let
       system = "x86_64-linux";
-      version = "1.0.0-a.27";
+      version = "1.0.0-a.28";
       downloadUrl = {
         "specific" = {
 	  url = "https://github.com/zen-browser/desktop/releases/download/${version}/zen.linux-specific.tar.bz2";
-	  sha256 = "sha256:0vmn10qpr96b4i8j24sa6ipg3fcxiiigkjwclbr5fknkfj3r6ds7";
+	  sha256 = "sha256:1vq7k3qwfdx70frng5p308zwnih86bwz75zpzcb1lbf3xsliz702";
 	};
 	"generic" = {
 	  url = "https://github.com/zen-browser/desktop/releases/download/${version}/zen.linux-generic.tar.bz2";
-	  sha256 = "sha256:1801pcvvmmdz5drqvxs95yzij099mhq7cnw663dna4kcn2nqwvni";
+	  sha256 = "sha256:154q0yl7s8v87dcpig8ixl607iqn1iv8mrlb82cldb1xn5gvlw5x";
 	};
       };
 


### PR DESCRIPTION
:wave: 

- Update browser to [1.0.0-a.28](https://github.com/zen-browser/desktop/releases/tag/1.0.0-a.28)
- Add runtime libs to fix VAAPI decoding (confirmed working on Intel GPU)
- Add runtime lib to enable Pipewire (screen sharing, microphone, etc.)
- Also add `udev`, not sure if it is necessary, I copied it from the [Firefox package](https://github.com/NixOS/nixpkgs/blob/c374d94f1536013ca8e92341b540eba4c22f9c62/pkgs/applications/networking/browsers/firefox/wrapper.nix) :shrug: 
- `libnotify` seems important to handle browser notifications, not sure if it was broken before though, could be a useless dependency too
- `cups` for printing because why not but didn't test it either

As you can see it's mostly dirty copying from the Firefox package but at least if makes VAAPI and Pipewire work :+1: 

Closes #7 