### PR TITLE
Fix gsettings and enable legacy profiles

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,9 +61,11 @@
 		fixupPhase = ''
 		  chmod 755 $out/bin/*
 		  patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/zen
-		  wrapProgram $out/bin/zen --set LD_LIBRARY_PATH "${pkgs.lib.makeLibraryPath runtimeLibs}"
+		  wrapProgram $out/bin/zen --set LD_LIBRARY_PATH "${pkgs.lib.makeLibraryPath runtimeLibs}" \
+                    --set MOZ_LEGACY_PROFILES 1 --set MOZ_ALLOW_DOWNGRADE 1 --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
 		  patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/zen-bin
-		  wrapProgram $out/bin/zen-bin --set LD_LIBRARY_PATH "${pkgs.lib.makeLibraryPath runtimeLibs}"
+		  wrapProgram $out/bin/zen-bin --set LD_LIBRARY_PATH "${pkgs.lib.makeLibraryPath runtimeLibs}" \
+                    --set MOZ_LEGACY_PROFILES 1 --set MOZ_ALLOW_DOWNGRADE 1 --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
 		  patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/glxtest
 		  wrapProgram $out/bin/glxtest --set LD_LIBRARY_PATH "${pkgs.lib.makeLibraryPath runtimeLibs}"
 		  patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/updater


### PR DESCRIPTION
- Prefix XDG_DATA_DIRS with the gsettings schema path
- Set the MOZ_LEGACY_PROFILES and MOZ_ALLOW_DOWNGRADE environment variables

These changes are copied from the [nixpkgs firefox wrapper](https://github.com/NixOS/nixpkgs/blob/c374d94f1536013ca8e92341b540eba4c22f9c62/pkgs/applications/networking/browsers/firefox/wrapper.nix#L322-L324).

I'm not sure if wrapGAppsHook is supposed to set XDG_DATA_DIRS automatically, but I've tried using it multiple times in the past and it doesn't seem to do that properly. Considering nixpkgs also sets it manually, I think this is a decent fix.

Currently, at least on my machine, running a new build of the derivation causes a new profile to be created in ~/.zen each time. Setting MOZ_LEGACY_PROFILES fixes this and uses the existing default profile. It seems MOZ_ALLOW_DOWNGRADE is also useful for nix so that you can revert any new builds and keep using the same profile.

Should close #4 