### PR TITLE
add icons of all sizes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,12 @@
 		installPhase = ''
 		  mkdir -p $out/bin && cp -r $src/* $out/bin
 		  install -D $desktopSrc/zen.desktop $out/share/applications/zen.desktop
+
+		  # install icons
+		  install -D $src/browser/chrome/icons/default/default16.png $out/share/icons/hicolor/16x16/apps/zen.png
+		  install -D $src/browser/chrome/icons/default/default32.png $out/share/icons/hicolor/32x32/apps/zen.png
+		  install -D $src/browser/chrome/icons/default/default48.png $out/share/icons/hicolor/48x48/apps/zen.png
+		  install -D $src/browser/chrome/icons/default/default64.png $out/share/icons/hicolor/64x64/apps/zen.png
 		  install -D $src/browser/chrome/icons/default/default128.png $out/share/icons/hicolor/128x128/apps/zen.png
 		'';
 


### PR DESCRIPTION
This pull request includes a small change to the `flake.nix` file. The change adds installation steps for additional icon sizes to the installation phase. This will let the compositor take the icon size it needs to avoid some weird ui glitches when alt + tab in budgie for ex.

* [`flake.nix`](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R60-R65): Added installation commands for 16x16, 32x32, 48x48, and 64x64 icon sizes.